### PR TITLE
Expand paths in layers to prevent passing an invalid path to HCS

### DIFF
--- a/src/Microsoft.Windows.ComputeVirtualization/ContainerStorage.cs
+++ b/src/Microsoft.Windows.ComputeVirtualization/ContainerStorage.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Windows.ComputeVirtualization
             public StorageFunctions.DriverInfo Data;
 
             public DriverInfoHelper()
-            {                
+            {
                 Data.Type = 1;
                 Data.Path = Marshal.StringToCoTaskMemUni("");
                 Marshal.WriteInt16(Data.Path, 0);
@@ -89,7 +89,7 @@ namespace Microsoft.Windows.ComputeVirtualization
                 for (int i = 0; i < layers.Count; i++)
                 {
                     Data[i].Id = layers[i].Id;
-                    Data[i].Path = Marshal.StringToCoTaskMemUni(layers[i].Path);
+                    Data[i].Path = Marshal.StringToCoTaskMemUni(Path.GetFullPath(layers[i].Path));
                 }
             }
 


### PR DESCRIPTION
Passing a null string as a path in a parent layer results in HCS attempting to access invalid memory (an uncatchable exception). By expanding the path to a full path before calling into HCS, proper exceptions are thrown in C# rather than in the native dll.

Signed-off-by: Darren Stahl darst@microsoft.com
