### PR TITLE
Fixing development build versions.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 'alpha4.{build}'
+version: '{build}'
 pull_requests:
   do_not_increment_build_number: true
 init:

--- a/src/Microsoft.Windows.ComputeVirtualization/project.json
+++ b/src/Microsoft.Windows.ComputeVirtualization/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0-*",
+  "version": "0.1.0-alpha4-*",
   "description": "Simple class library to interface with Windows host compute service.",
   "copyright": "© Microsoft Corporation. All rights reserved.",
   "authors": [


### PR DESCRIPTION
@jstarks 
This will make the dev NuGet package version of the form X.Y.Z-{release}-{build} so that publishing the package will actually work.
