### PR TITLE
Fix the problem that Microsoft.Windows.ComputeVirtualization.HostComputeService.GetComputeSystem is unusable

### DIFF
--- a/src/Microsoft.Windows.ComputeVirtualization/Container.cs
+++ b/src/Microsoft.Windows.ComputeVirtualization/Container.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Win32.SafeHandles;
+using Microsoft.Win32.SafeHandles;
 using System;
 using System.IO;
 using System.Text;
@@ -40,7 +40,7 @@ namespace Microsoft.Windows.ComputeVirtualization
             _watcher = watcher;
         }
 
-        internal static Container Initialize(string id, IntPtr computeSystem, bool terminateOnClose, IHcs hcs = null)
+        internal static Container Initialize(string id, IntPtr computeSystem, bool terminateOnClose, bool createNewContainer, IHcs hcs = null)
         {
             var h = hcs ?? HcsFactory.GetHcs();
             var watcher = new HcsNotificationWatcher(
@@ -59,7 +59,10 @@ namespace Microsoft.Windows.ComputeVirtualization
                 terminateOnClose,
                 watcher,
                 h);
-            watcher.Wait(HCS_NOTIFICATIONS.HcsNotificationSystemCreateCompleted);
+            if (createNewContainer)
+            {
+                watcher.Wait(HCS_NOTIFICATIONS.HcsNotificationSystemCreateCompleted);
+            }
 
             return container;
         }

--- a/src/Microsoft.Windows.ComputeVirtualization/HostComputeService.cs
+++ b/src/Microsoft.Windows.ComputeVirtualization/HostComputeService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.ComponentModel;
@@ -141,7 +141,7 @@ namespace Microsoft.Windows.ComputeVirtualization
 
             IntPtr computeSystem;
             h.CreateComputeSystem(id, JsonHelper.ToJson(hcsSettings), IntPtr.Zero, out computeSystem);
-            return Container.Initialize(id, computeSystem, settings.KillOnClose, h);
+            return Container.Initialize(id, computeSystem, settings.KillOnClose, true, h);
         }
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace Microsoft.Windows.ComputeVirtualization
             var h = hcs ?? HcsFactory.GetHcs();
             h.OpenComputeSystem(id, out computeSystem);
 
-            return Container.Initialize(id, computeSystem, false, h);
+            return Container.Initialize(id, computeSystem, false, false, h);
         }
     }
 }


### PR DESCRIPTION
That function stalls when called because the container is already created, so the wait is unnecessary.