### PR TITLE
Prevent hang on HostComputeService.GetComputeSystem.

### DIFF
--- a/src/Microsoft.Windows.ComputeVirtualization/Container.cs
+++ b/src/Microsoft.Windows.ComputeVirtualization/Container.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Windows.ComputeVirtualization
             _watcher = watcher;
         }
 
-        internal static Container Initialize(string id, IntPtr computeSystem, bool terminateOnClose, IHcs hcs = null)
+        internal static Container Initialize(string id, IntPtr computeSystem, bool terminateOnClose, bool creatingContainer, IHcs hcs = null)
         {
             var h = hcs ?? HcsFactory.GetHcs();
             var watcher = new HcsNotificationWatcher(
@@ -59,7 +59,8 @@ namespace Microsoft.Windows.ComputeVirtualization
                 terminateOnClose,
                 watcher,
                 h);
-            watcher.Wait(HCS_NOTIFICATIONS.HcsNotificationSystemCreateCompleted);
+            if (creatingContainer)
+               watcher.Wait(HCS_NOTIFICATIONS.HcsNotificationSystemCreateCompleted); 
 
             return container;
         }

--- a/src/Microsoft.Windows.ComputeVirtualization/HostComputeService.cs
+++ b/src/Microsoft.Windows.ComputeVirtualization/HostComputeService.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Windows.ComputeVirtualization
 
             IntPtr computeSystem;
             h.CreateComputeSystem(id, JsonHelper.ToJson(hcsSettings), IntPtr.Zero, out computeSystem);
-            return Container.Initialize(id, computeSystem, settings.KillOnClose, h);
+            return Container.Initialize(id, computeSystem, settings.KillOnClose, true, h);
         }
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace Microsoft.Windows.ComputeVirtualization
             var h = hcs ?? HcsFactory.GetHcs();
             h.OpenComputeSystem(id, out computeSystem);
 
-            return Container.Initialize(id, computeSystem, false, h);
+            return Container.Initialize(id, computeSystem, false, false, h);
         }
     }
 }


### PR DESCRIPTION
Made my own fixes to the class since this pull request @ [here](https://github.com/Microsoft/dotnet-computevirtualization/pull/22) doesn't seem like it'll be merged any time soon.

e.g. only wait for container creation to complete if we're actually creating a container.
