### PR TITLE
Update tests to use 2.0 runtime

### DIFF
--- a/src/Microsoft.Windows.ComputeVirtualization/Microsoft.Windows.ComputeVirtualization.csproj
+++ b/src/Microsoft.Windows.ComputeVirtualization/Microsoft.Windows.ComputeVirtualization.csproj
@@ -5,7 +5,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <VersionPrefix>0.1.0-alpha5</VersionPrefix>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>net46;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard1.3;netcoreapp2.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Microsoft.Windows.ComputeVirtualization</AssemblyName>
     <PackageId>Microsoft.Windows.ComputeVirtualization</PackageId>

--- a/test/Microsoft.Windows.ComputeVirtualization.Tests/Microsoft.Windows.ComputeVirtualization.Tests.csproj
+++ b/test/Microsoft.Windows.ComputeVirtualization.Tests/Microsoft.Windows.ComputeVirtualization.Tests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>Microsoft.Windows.ComputeVirtualization.Tests</AssemblyName>
     <PackageId>Microsoft.Windows.ComputeVirtualization.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RuntimeIdentifiers>win81-x64</RuntimeIdentifiers>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
+    <RuntimeFrameworkVersion>2.0.3</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,14 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
-    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-    <PackageReference Include="System.Runtime" Version="4.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
With the update to 2.0 SDK, the tests need updating as well to run against the 2.0 runtime. This updates the target framework, runtime, xunit version, and test SDK version. 

Signed-off-by: Darren Stahl <darst@microsoft.com>

@jterry75 